### PR TITLE
Update Python CI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,8 @@ jobs:
         os:
           - ubuntu-latest
         splunk-version:
-          - "8.0"
+          - "8.1"
+          - "8.2"
           - "latest"
       fail-fast: false
 


### PR DESCRIPTION
First commit adds Dependabot for github-actions, so this repository will receive updates when new version of Github Actions come out (like, actions/checkout, actions/setup-python etc).

Second commit updates the Splunk versions to run.